### PR TITLE
fix: 修复bin 文件少了#! /usr/bin/env node 环境声明，导致npm 下载的无法启动改服务

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -1,3 +1,5 @@
+#! /usr/bin/env node
+
 const { program } = require('commander');
 const pkg = require('../package.json');
 program.version(pkg.version, '-v, --version').usage('<command> [options]');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enhances/mock-server",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "mock 服务器, 开箱即用，无需重启,自动代理远程服务、提供静态web服务入口、零接入成本",
   "type": "commonjs",
   "main": "dist/commonjs/index.js",


### PR DESCRIPTION
fix: 修复bin 文件少了#! /usr/bin/env node 环境声明，导致npm 下载的无法启动改服务